### PR TITLE
peticion DELETE (borrado logico) para Vianda y Carta

### DIFF
--- a/src/app/api/carta/[cartaId]/route.js
+++ b/src/app/api/carta/[cartaId]/route.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { prisma } from '../../../../libs/prisma'
+import { prisma } from '@/libs/prisma'
 
 export async function DELETE(request, { params }) {
   try {

--- a/src/app/api/carta/[cartaId]/route.js
+++ b/src/app/api/carta/[cartaId]/route.js
@@ -1,0 +1,27 @@
+import { NextResponse } from "next/server"
+import { prisma } from '../../../../libs/prisma'
+
+export async function DELETE(request, { params }) {
+  try {
+    // Se busca la carta a traves de params
+    const carta = await prisma.Carta.findUnique({
+      where: { id: Number(params.cartaId) },
+      select: { status: true },
+    });
+
+    // Se evalua si existe la carta
+    if (!carta) {
+      return NextResponse.json("Carta no encontrada", { status: 404 });
+    }
+
+    // Se invierte el valor booleano {status}
+    await prisma.Carta.update({
+      where: { id: Number(params.cartaId) },
+      data: { status: !carta.status },
+    });
+
+    return NextResponse.json("Carta modificada correctamente");
+  } catch (error) {
+    return NextResponse.json("Error al intentar modificar la carta", { status: 403 });
+  }
+}

--- a/src/app/api/viandas/[viandaId]/route.js
+++ b/src/app/api/viandas/[viandaId]/route.js
@@ -1,11 +1,27 @@
 import { NextResponse } from "next/server"
+import { prisma } from '../../../../libs/prisma'
 
-const DELETE = ({ params }) => {
+export async function DELETE(request, { params }) {
   try {
-    return NextResponse.json()
+    // Se busca la vianda a traves de params
+    const vianda = await prisma.Vianda.findUnique({
+      where: { id: Number(params.viandaId) },
+      select: { status: true },
+    });
+
+    // Se evalua si existe la vianda
+    if (!vianda) {
+      return NextResponse.json("Vianda no encontrada", { status: 404 });
+    }
+
+    // Se invierte el valor booleano {status}
+    await prisma.Vianda.update({
+      where: { id: Number(params.viandaId) },
+      data: { status: !vianda.status },
+    });
+
+    return NextResponse.json("Vianda modificada correctamente");
   } catch (error) {
-    return NextResponse.json("deleted", { status: 403 })
+    return NextResponse.json("Error al intentar modificar la carta", { status: 403 });
   }
 }
-
-export default DELETE

--- a/src/app/api/viandas/[viandaId]/route.js
+++ b/src/app/api/viandas/[viandaId]/route.js
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server"
-import { prisma } from '../../../../libs/prisma'
+import { prisma } from '@/libs/prisma'
 
 export async function DELETE(request, { params }) {
   try {


### PR DESCRIPTION
1. Se crearon las rutas:

- /api/viandas/[viandaId]
- /api/carta/[cartaId]

2. Para cada ruta se creó un archivo route.js con la lógica de petición DELETE que en realidad es un borrado lógico.

**La petición DELETE funciona tanto para desactivar, como para activar (invierte el valor booleano de status)**

Adjunto screenshot del código para el borrado lógico de Vianda (para el caso de Carta, es exactamente lo mismo)

![viandaBorrado](https://github.com/ProyectoFinal-Henry/Vianda-app/assets/123340872/30599ce2-5e54-4cd3-8e57-6b8fe4c1f77e)
