### PR TITLE
Ordenamiento y búsqueda por query

### DIFF
--- a/src/app/api/viandas/route.js
+++ b/src/app/api/viandas/route.js
@@ -42,6 +42,9 @@ export async function GET(request) {
         where: {
           AND: whereCondicion,
         },
+        orderBy: {
+          nombre: "asc"
+        }
       });
 
       if (!viandas || viandas.length === 0) {
@@ -52,13 +55,15 @@ export async function GET(request) {
     } catch (error) {
       return NextResponse.json({ error: error.message });
     }
-  }
-  else{
+  } else {
     try {
-      const viandas = await prisma.Vianda.findMany();
+      const viandas = await prisma.Vianda.findMany({
+        orderBy: {
+          nombre: "asc"
+        }
+      });
       return NextResponse.json(viandas);
     } catch (error) {
-      console.log(error)
       return NextResponse.json("Error al obtener las viandas");
     }
   }

--- a/src/app/api/viandas/route.js
+++ b/src/app/api/viandas/route.js
@@ -9,6 +9,13 @@ export async function GET(request) {
       const ing2 = searchParams.get("ing2");
       const ing3 = searchParams.get("ing3");
       const tipo = searchParams.get("tipo");
+      let search = searchParams.get("search");
+      let campo = searchParams.get("campo");
+      let orden = searchParams.get("orden");
+      if (!search) search = ""
+      if (!orden) orden = "asc"
+      if (!campo) campo = "id"
+
       const whereCondicion = [];
       if (ing1) {
         whereCondicion.push({
@@ -40,15 +47,19 @@ export async function GET(request) {
 
       const viandas = await prisma.Vianda.findMany({
         where: {
+          nombre: {
+            contains: search,
+            mode: 'insensitive'
+          },
           AND: whereCondicion,
         },
         orderBy: {
-          nombre: "asc"
+          [campo]: orden
         }
       });
 
       if (!viandas || viandas.length === 0) {
-        return NextResponse.json("No se encontró una vianda que contenga estos elementos entre sus ingredientes.");
+        return NextResponse.json("No se encontró una vianda que contenga la información requerida");
       }
 
       return NextResponse.json(viandas);
@@ -59,7 +70,7 @@ export async function GET(request) {
     try {
       const viandas = await prisma.Vianda.findMany({
         orderBy: {
-          nombre: "asc"
+          id: "asc"
         }
       });
       return NextResponse.json(viandas);


### PR DESCRIPTION
Se implementó ordenamiento de Viandas (según el campo deseado) y búsqueda por query.
Ejemplos:

/viandas?search=empa
_Busca todas las viandas que comiencen con "empa"_

/viandas?campo=nombre
_Busca todas las viandas y las ordena por nombre_

/viandas?campo=stock&orden=desc
_Busca todas las viandas y las ordenas por stock de forma descendente_

**Todas las query son combinables (también con los filtros)**
