### PR TITLE
se corrigió bug del Logout

### DIFF
--- a/src/components/adminLayout/NavAdmin.jsx
+++ b/src/components/adminLayout/NavAdmin.jsx
@@ -13,6 +13,7 @@ const NavAdmin = () => {
   const logout = async () =>{
     const response = await axios.post("/api/auth/logout")
     if (response.status === 200){
+      router.refresh()
       router.push('/')
     }
   }


### PR DESCRIPTION
El bug era que si hacias logout, y luego ibas para atrás con el navegador, podías acceder a la página Admin sin estar logeado.

Se corrigió agegando router.refresh() antes de redireccionar