### PR TITLE
Creardor de menu FixV2

### DIFF
--- a/src/app/admin/menu/page.jsx
+++ b/src/app/admin/menu/page.jsx
@@ -9,7 +9,7 @@ import { useState, useEffect } from "react"
 
 const MenuPageAdmin = () => {
   const [viandas, setViandas] = useState([])
-
+  
   const viandasGetter = async () => {
     const res = await axios.get(`/api/menu?all=true`)
     setViandas(res.data)
@@ -19,6 +19,17 @@ const MenuPageAdmin = () => {
       viandasGetter()
     }
   }, [])
+  
+  const handleResetViandas = async() => {
+    const objetoReset = {}
+  try {
+    const res = await axios.delete(`/api/menu?reset=true`)
+  } catch (error) {
+      throw new Error(error.message)
+  }
+  window.location.reload() //!OJO CON ESTO!
+  }
+  
   const semana = ["lunes", "martes", "miercoles", "jueves", "viernes"]
   return (
     <>
@@ -26,6 +37,7 @@ const MenuPageAdmin = () => {
         {viandas.length !== 0 ? (
           <>
             <div className="flex flex-row justify-end flex-wrap gap-4 items-right w-full md:max-w-[896px] ">
+              <button onClick={handleResetViandas}>Boton Feo</button>
               <Link
                 href={"/admin/menu/issue-menu"}
                 className="btn btn-sm btn-primary rounded-md "
@@ -36,7 +48,6 @@ const MenuPageAdmin = () => {
             {semana.map((dia) => (
               <div key={dia}>
                 {dia !== "lunes" && <div className={"divider"}></div>}
-
                 <div className="flex flex-row justify-start items-center gap-8 ">
                   <h1 className="text-3xl  font-bold   ">
                     Viandas para el <span className="capitalize">{dia}</span>{" "}
@@ -48,7 +59,6 @@ const MenuPageAdmin = () => {
                     exportar {dia} <GiFoodTruck className=" text-2xl" />
                   </Link>
                 </div>
-
                 <div
                   id="menuRow"
                   className="flex flex-row justify-center flex-wrap gap-4 items-center min-w-full"

--- a/src/app/api/menu/route.js
+++ b/src/app/api/menu/route.js
@@ -45,3 +45,29 @@ export async function POST(request) {
     return NextResponse.json({ message: error.message });
   }
 }
+
+
+
+export async function DELETE(request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const reset = searchParams.get("reset");
+
+    if (reset) {
+      const semanaReset = await prisma.vianda.updateMany({
+        data: {
+          lunes: false,
+          martes: false,
+          miercoles: false,
+          jueves: false,
+          viernes: false,
+          sabado: false,
+          domingo: false,
+        }
+      })
+      return NextResponse.json("Reset de semana ok!");
+    }
+  } catch (error) {
+    return NextResponse.json({ message: error.message });
+  }
+}

--- a/src/components/adminLayout/menu/CardsMenu.jsx
+++ b/src/components/adminLayout/menu/CardsMenu.jsx
@@ -4,7 +4,7 @@ import { FcOk } from "react-icons/fc"
 import { currencyFormater } from "@/libs/utils/currencyFormater"
 import axios from "axios"
 import { useEffect, useState } from "react"
-import { set } from "react-hook-form"
+
 
 const CardsMenu = ({ viandas, dia, tipo, setViandas}) => {
   const [loader, setLoader] = useState("off")
@@ -33,8 +33,6 @@ const CardsMenu = ({ viandas, dia, tipo, setViandas}) => {
 
   const updateVianda = async (e) => {
     e.target.value === "" && setViandaSeleccionada(viandaVacia)
-
-  
     setLoader("on")
 
     try {
@@ -128,7 +126,7 @@ const CardsMenu = ({ viandas, dia, tipo, setViandas}) => {
                     onChange={updateVianda}
                   >
                     Escoger Vianda
-                    <option key={0} value={"sinSeleccion"}>Sin seleccion</option>
+                    <option key={0} value={"sinSeleccion"}>Seleccionar</option>
                     {viandasPorTipo.map(({ id, nombre }) => (
                       <option
                         key={id}


### PR DESCRIPTION
* Se corrigió la leyenda "sin selección" en las card del creador de menu, se remplazo por "Seleccionar".
* Se agrego el delete de la ruta de `/api/menu, que en realidad no borra, sino que resetea a (false) todos los días de todas las viandas.
* Se agrego el botón que dispara el reset en el page de /admin/menu. (Sin estilos). No se logro re-renderizar todas las cards así que se utilizo un windows.reload para que quede funcional. 
No es lo mejor que se puede hacer. Pero hago el push para que se pueda seguir trabajando sobre el archivo.
Se intento con useEffect y estado auxiliar, tanto en componente padre como en los componentes hijos pero no se logro. 

El componente se encuentra funcional, pero puede ser mejorado.